### PR TITLE
remove the `Hash` derivation for Spanned and Variable

### DIFF
--- a/werbolg-core/src/ir.rs
+++ b/werbolg-core/src/ir.rs
@@ -182,5 +182,5 @@ pub enum Expr {
 }
 
 /// A variable (function parameter)
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Variable(pub Spanned<Ident>);

--- a/werbolg-core/src/location.rs
+++ b/werbolg-core/src/location.rs
@@ -40,7 +40,7 @@ where
 ///
 /// The Eq instance of Span, doesn't check that the span are equal,
 /// for explicit checking using `span_eq`
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct Spanned<T> {
     /// The span of T
     pub span: Span,


### PR DESCRIPTION
not only it is not used, but also it's not very well understood the consequences of having a different `PartialEq` and a `Hash` implementation that does not provide correct values in case of collision.