### PR TITLE
fix test of the documentation

### DIFF
--- a/werbolg-exec/src/exec.rs
+++ b/werbolg-exec/src/exec.rs
@@ -25,6 +25,7 @@
 //!
 //! Function Stack after a 'Call' operation:
 //!
+//! ```text
 //!      ┌──────────────────┬───────────────────────┐
 //!      │                  │                       │
 //!      │ Fun callee stack │  Fun local stack      │
@@ -35,9 +36,11 @@
 //!                         │                       │
 //!                         ▼                       ▼
 //!                        SP                    Stack top
+//! ```
 //!
 //! After a 'Ret' operation:
 //!
+//! ```text
 //!  ──┬─┬──────┐
 //!  ..|X│RetVal│
 //!  ──┴─┴──────┤
@@ -52,6 +55,7 @@
 //!  ┤────────┴─┴─┼──────┴──┴──────┤
 //!  ▼            ▼                ▼
 //! Stack bottom  SP            Stack top
+//! ```
 //!
 use crate::{CallSave, Valuable};
 


### PR DESCRIPTION
when running rust, the spaces works the same as the quote code. being explicit removes the compiler not understanding the the special unicode character and thinking it's documented code example to execute